### PR TITLE
Fix smallest_prime_of_bitlength exception

### DIFF
--- a/lib/secretsharing/shamir/share.rb
+++ b/lib/secretsharing/shamir/share.rb
@@ -21,6 +21,7 @@ module SecretSharing
     # a polynomial over Z/Zp, where p is a prime.
     class Share
       include SecretSharing::Shamir
+      extend SecretSharing::Shamir
       attr_accessor :share, :version, :hmac, :k, :n, :x, :y, :prime, :prime_bitlength
 
       def initialize(opts = {})

--- a/spec/shamir_spec.rb
+++ b/spec/shamir_spec.rb
@@ -16,11 +16,12 @@
 
 require File.expand_path('../spec_helper', __FILE__)
 
-include SecretSharing::Shamir
 
 describe SecretSharing::Shamir do
 
   describe 'usafe_encode64 and usafe_decode64' do
+
+    include SecretSharing::Shamir
 
     it 'will encode and decode back to the original String' do
       str = MultiJson.dump(:foo => 'bar', :bar => 12_345_678_748_390_743_789)


### PR DESCRIPTION
Share.create_shares was referencing `smallest_prime_of_bitlength`, which was only defined at the instance level. This was being masked by a top-level include in one spec.

Fix by using `extend` to make the method available as a class method.
