### PR TITLE
Fix prime number generation

### DIFF
--- a/lib/secretsharing/shamir.rb
+++ b/lib/secretsharing/shamir.rb
@@ -35,25 +35,6 @@ module SecretSharing
       rand
     end
 
-    # Computes the smallest prime of a given bitlength. Uses prime_fasttest
-    # from the OpenSSL library with 20 attempts to be compatible to openssl
-    # prime, which is used in the OpenXPKI::Crypto::Secret::Split library.
-    def smallest_prime_of_bitlength(bitlength)
-      # start with 2^bit_length + 1
-      test_prime = OpenSSL::BN.new((2**bitlength + 1).to_s)
-      prime_found = false
-
-      until prime_found
-        # prime_fasttest? 20 do be compatible to
-        # openssl prime, which is used in
-        # OpenXPKI::Crypto::Secret::Split
-        prime_found = test_prime.prime_fasttest?(20)
-        test_prime += 2
-      end
-
-      test_prime
-    end
-
     # Evaluate the polynomial at x.
     def evaluate_polynomial_at(x, coefficients, prime)
       result = OpenSSL::BN.new('0')

--- a/lib/secretsharing/shamir/share.rb
+++ b/lib/secretsharing/shamir/share.rb
@@ -86,7 +86,7 @@ module SecretSharing
         # round up to next nibble
         next_nibble_bitlength = secret.bitlength + (4 - (secret.bitlength % 4))
         prime_bitlength       = next_nibble_bitlength + 1
-        prime                 = smallest_prime_of_bitlength(prime_bitlength)
+        prime                 = OpenSSL::BN.generate_prime(prime_bitlength)
 
         # compute random coefficients
         (1..k - 1).each { |x| coefficients[x] = get_random_number(secret.bitlength) }

--- a/spec/shamir_container_spec.rb
+++ b/spec/shamir_container_spec.rb
@@ -227,6 +227,23 @@ describe SecretSharing::Shamir::Container do
         @c3.secret = SecretSharing::Shamir::Secret.new
       end
 
+      # This exposed a bug in the prime number generation; for instance 4*8
+      # passes.
+      it 'should be able to recover secret with a bitlength of 5*8' do
+        secret = SecretSharing::Shamir::Secret.new(:secret => get_random_number(5*8))
+        c = SecretSharing::Shamir::Container.new(4,2)
+        c.secret = secret
+
+        (0...4).to_a.permutation(2).collect{|e| e.sort}.uniq.each do |indexes|
+          c2 = SecretSharing::Shamir::Container.new(2)
+          indexes.each do |index|
+            c2 << c.shares[index]
+          end
+          c2.secret?.must_equal(true)
+          c2.secret.must_equal(c.secret)
+        end
+      end
+
       it 'should be able to recover secret when k equals n and all k shares are provided as Shamir::Share objects' do
         @c2 << @c1.shares[0]
         @c2 << @c1.shares[1]


### PR DESCRIPTION
Prime number generation was via a non-standard brute-force method, and it generated primes(?) that didn't work for all secret bitlengths. See #3 for the error that was triggered.

Switching to just having OpenSSL generate the prime directly fixes the issue for all bitlengths.

Includes a test that shows the issue by using a bitlength that failed under all conditions with the old prime generation algorithm.
